### PR TITLE
Add tools API endpoint and update client

### DIFF
--- a/src/app/api/tools/route.ts
+++ b/src/app/api/tools/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+import { tools } from "@/lib/tools";
+
+export async function GET() {
+  return NextResponse.json({ tools }, { status: 200 });
+}

--- a/src/components/ToolsClient.tsx
+++ b/src/components/ToolsClient.tsx
@@ -1,11 +1,26 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
-import { Tool, getAllTools } from "@/lib/tools";
+import React, { useState, useMemo, useEffect } from "react";
+import { Tool } from "@/lib/tools";
 import ToolCard from "./ToolCard";
 
 export default function ToolsClient() {
-  const allTools: Tool[] = getAllTools();
+  const [allTools, setAllTools] = useState<Tool[]>([]);
+
+  useEffect(() => {
+    async function fetchTools() {
+      try {
+        const res = await fetch("/api/tools");
+        if (!res.ok) throw new Error(`API error ${res.status}`);
+        const data = await res.json();
+        setAllTools(Array.isArray(data.tools) ? data.tools : []);
+      } catch (err) {
+        console.error("\u274c Failed to load tools:", err);
+      }
+    }
+
+    fetchTools();
+  }, []);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- add an API route that returns the tool catalog
- fetch tool data client-side in `ToolsClient`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e1566c38832e8e04dd2ab0228ab5