### PR TITLE
Add canonical metadata

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -23,6 +23,8 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
   const post = await getPostHtmlBySlug(params.slug);
   if (!post) return {};
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://ikoconnect.com";
+
   const ogImageAbsolute = post.coverImage?.startsWith("http")
     ? post.coverImage
     : `https://www.ikoconnect.com${post.coverImage || "/images/og/default.png"}`;
@@ -30,6 +32,9 @@ export async function generateMetadata({ params }: PageParams): Promise<Metadata
   return {
     title: post.title,
     description: post.description,
+    alternates: {
+      canonical: `${siteUrl}/blog/${params.slug}`,
+    },
     openGraph: {
       title: post.title,
       description: post.description,

--- a/src/app/tools/[id]/page.tsx
+++ b/src/app/tools/[id]/page.tsx
@@ -27,12 +27,20 @@ export async function generateMetadata({
     };
   }
 
-  return buildBasicMetadata({
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://ikoconnect.com";
+  const basic = buildBasicMetadata({
     title: `${maybeTool.name} – IkoConnect Tool`,
     description: maybeTool.description,
     path: `/tools/${maybeTool.id}`,
     ogImage: maybeTool.logo,
   });
+
+  return {
+    ...basic,
+    alternates: {
+      canonical: `${siteUrl}/tools/${maybeTool.id}`,
+    },
+  };
 }
 
 export default function ToolDetailPage({ params }: PageParams) {


### PR DESCRIPTION
## Summary
- ensure blog pages and tool detail pages include canonical URLs in metadata

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840e9f63420832e82cbdcf8172a5bac