### PR TITLE
Add ESLint and Prettier configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["next/core-web-vitals", "eslint-config-prettier"],
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "find-unused-exports": "ts-prune src --ignore \"src/app/head.tsx\" --ignore \".next\"",
     "find-orphans": "madge --orphans src",
     "start": "next start -p 3000",
-    "update-jobs": "node scripts/update-jobs.js"
+    "update-jobs": "node scripts/update-jobs.js",
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
@@ -82,6 +84,8 @@
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",
     "ts-prune": "^0.10.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "prettier": "^3.2.5",
+    "eslint-config-prettier": "^9.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `.eslintrc.js` and `.prettierrc` configs
- add `lint` and `format` npm scripts with Prettier dev dependencies

## Testing
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6840ebe4bfc0832e98af86cda78a325f