### PR TITLE
Remove Navbar component from RootLayout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import Providers from "@/components/Providers";
-import Navbar from "@/components/Navbar";
 import JSONLD from "@/components/JSONLD";
 import {
   generateOrganizationJsonLD,
@@ -120,7 +119,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </head>
       <body className="flex flex-col min-h-screen antialiased scroll-smooth bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200">
         <Providers>
-          <Navbar />
           <main id="main-content" className="flex-1 pt-20">{children}</main>
         </Providers>
       </body>


### PR DESCRIPTION
## Summary
- remove `Navbar` import from RootLayout
- rely on `Providers` to render `NavbarClient`

## Testing
- `npm run lint` *(fails: `next` missing, offline)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7e7f944832e9cfc19dab15a6818